### PR TITLE
Chown backup directory to resolve #5 (Permission denied errors)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,16 @@
   tags:
     - autopostgresqlbackup
 
+- name: Make sure backup directory exists and is writeable (owned) by postgres user
+  file:
+    path={{ autopostgresqlbackup_backup_directory }}
+    state=directory
+    recurse=yes
+    owner=postgres
+    group=postgres
+  tags:
+    - autopostgresqlbackup
+
 - name: remove the cron.daily file
   sudo: yes
   file: path=/etc/cron.daily/autopostgresqlbackup state=absent


### PR DESCRIPTION
This stops the Permission denied email for me.

Credit to this answer

https://www.odoo.com/nl_NL/forum/help-1/question/permission-denied-error-when-using-pg-dump-to-backup-database-61814#answer_102852